### PR TITLE
show term ID is now responsive in explain path

### DIFF
--- a/source/DAGView.cs
+++ b/source/DAGView.cs
@@ -665,6 +665,11 @@ namespace AxiomProfiler
             return curPath;
         }
 
+        // TODO: Need to change this function to accomdate the new algorithm
+        // Arguments: Node (the selected node), nodesToGO (the bound)
+        // Perform BFS search bounded by nodesToGo,
+        // Keeping track the path used to reach the current node from the selected node
+        // return paths that reaches a node of the same type as the selected node
         private static IEnumerable<InstantiationPath> AllDownPaths(InstantiationPath basePath, Node node, int nodesToGo)
         {
             if (nodesToGo <= 0 || !node.OutEdges.Any()) return Enumerable.Repeat(basePath, 1);

--- a/source/DAGView.cs
+++ b/source/DAGView.cs
@@ -507,10 +507,6 @@ namespace AxiomProfiler
                         highlightPath(cyclePath);
                         _z3AxiomProfiler.UpdateSync(cyclePath);
                         toRemove = cyclePath.GetInstnationsUnusedInGeneralization();
-                        if (cyclePath.NeedsIds())
-                        {
-                            _z3AxiomProfiler.EnableTermIds();
-                        }
                     }
                     else
                     {

--- a/source/DAGView.cs
+++ b/source/DAGView.cs
@@ -641,11 +641,11 @@ namespace AxiomProfiler
             var curNode = node;
             var curPath = new InstantiationPath();
             curPath.append((Instantiation)node.UserData);
-            while (curNode.OutEdges.Any())
-            {
-                curPath = AllDownPaths(curPath, curNode, pathSegmentSize).OrderByDescending(path => InstantiationPathScoreFunction(path, false, true)).First();
-                curNode = graph.FindNode(curPath.getInstantiations().Last().uniqueID);
-            }
+            //while (curNode.OutEdges.Any())
+            //{
+            //    curPath = AllDownPaths(curPath, curNode, pathSegmentSize).OrderByDescending(path => InstantiationPathScoreFunction(path, false, true)).First();
+            //    curNode = graph.FindNode(curPath.getInstantiations().Last().uniqueID);
+            //}
             return curPath;
         }
 

--- a/source/QuantifierModel/InstantiationPath.cs
+++ b/source/QuantifierModel/InstantiationPath.cs
@@ -561,10 +561,6 @@ namespace AxiomProfiler.QuantifierModel
             if (!hasCycle()) return;
             var cycle = cycleDetector.getCycleQuantifiers();
             var generalizationState = cycleDetector.getGeneralization();
-            if (generalizationState.NeedsIds)
-            {
-                format.showTermId = true;
-            }
 
             if (generalizationState.TrueLoop)
             {


### PR DESCRIPTION
resolves issue #17  
@alexanderjsummers 
'show term id' now is responsive during explain path, and is by default off