### PR TITLE
show term ID is now responsive in explain path

### DIFF
--- a/source/DAGView.cs
+++ b/source/DAGView.cs
@@ -507,10 +507,6 @@ namespace AxiomProfiler
                         highlightPath(cyclePath);
                         _z3AxiomProfiler.UpdateSync(cyclePath);
                         toRemove = cyclePath.GetInstnationsUnusedInGeneralization();
-                        if (cyclePath.NeedsIds())
-                        {
-                            _z3AxiomProfiler.EnableTermIds();
-                        }
                     }
                     else
                     {

--- a/source/QuantifierModel/InstantiationPath.cs
+++ b/source/QuantifierModel/InstantiationPath.cs
@@ -561,10 +561,6 @@ namespace AxiomProfiler.QuantifierModel
             if (!hasCycle()) return;
             var cycle = cycleDetector.getCycleQuantifiers();
             var generalizationState = cycleDetector.getGeneralization();
-            if (generalizationState.NeedsIds)
-            {
-                format.showTermId = true;
-            }
 
             if (generalizationState.TrueLoop)
             {


### PR DESCRIPTION
Deleting line from QuantifierModel/InstantiationPath.cs and DAGView.cs to make the 'show term ID check box' :
- responsive during explaining path.
- do not change its current state when the user clicks 'explain path'
- resolves issue #17 